### PR TITLE
Simpler conda-setup.sh

### DIFF
--- a/conda-setup.sh
+++ b/conda-setup.sh
@@ -1,9 +1,7 @@
 #! /bin/bash
+
 ENV_NAME=2015-geospatial
-conda create --yes -n $ENV_NAME python=2  fiona shapely rasterio pandas basemap requests
-conda install --yes -n $ENV_NAME -c ocefpaf rtree
-conda install --yes -n $ENV_NAME -c asmeurer pyproj descartes
-source activate $ENV_NAME
-pip install git+git://github.com/geopandas/geopandas.git
-pip install github3.py
-pip install --no-deps geojsonio  # Use --no-peds to avoid downgrading six and github3.py
+
+conda config --add channels ioos
+
+conda create -n $ENV_NAME --file req.txt python=2.7

--- a/req.txt
+++ b/req.txt
@@ -1,0 +1,12 @@
+pyproj
+fiona
+shapely
+rasterio
+geopandas
+basemap
+cartopy
+geojsonio
+pandas
+requests
+rtree
+descartes

--- a/req.txt
+++ b/req.txt
@@ -10,3 +10,4 @@ pandas
 requests
 rtree
 descartes
+ipython-notebook


### PR DESCRIPTION
This PR
- Removes the packages from `ocefpaf` and `asmeurer` channels (Mine is experimental and should not be used!)
- Adds the [IOOS](https://github.com/ioos/conda-recipes) (This is stable)
- Simplified the bash script to use a requirement file.  The script does not work on Windows, but all packages are available for OSX, Win32/64, and Linux32/64
